### PR TITLE
Some quick and dirty fixes to the causation graphs

### DIFF
--- a/components/indicators/IndicatorCausal.js
+++ b/components/indicators/IndicatorCausal.js
@@ -110,7 +110,7 @@ const Connection = styled.div`
         return '#333333';
     }
   }};
-  transform: ${props => `rotate(${props.rotate * 90}deg)`};
+  /*transform: ${props => `rotate(${props.direction * 90}deg)`};*/
   &:before {
     content: '';
     position: absolute;
@@ -248,7 +248,9 @@ class IndicatorCausal extends React.Component {
     if (columned[index].indicator_level !== 'strategic') {
       columned[index].from.forEach((edge) => {
         const nodeIndex = columned.findIndex(item => item.id === edge.to);
-        this.setColumns(columned, nodeIndex, column + 1);
+	if (!('column' in nodes[nodeIndex])) {
+          this.setColumns(columned, nodeIndex, column + 1);
+	}
       });
     }
     return columned;
@@ -347,9 +349,17 @@ class IndicatorCausal extends React.Component {
     if (edgeLength === 0) {
       edgeStyle.width = '1px';
       edgeStyle.height = `${24}px`;
-      edgeStyle.top = '-24px';
+      if(edgeHeight < 0) {
+      	edgeStyle.bottom = '-24px';
+	edgeStyle.top = undefined;
+	direction = -1;
+      } else {
+        // TODO: This case hasn't been tested!
+	edgeStyle.top = '-24px';
+	direction = 1;
+
+      }
       edgeStyle.left = `${40 + (vOffset * 5)}px`;
-      direction = (edgeHeight >= 0) ? 1 : -1;
     }
 
     return (

--- a/components/indicators/IndicatorCausal.js
+++ b/components/indicators/IndicatorCausal.js
@@ -296,9 +296,31 @@ class IndicatorCausal extends React.Component {
       });
     });
   }
+  
+  isConnectedToOutcome (node, nodes, edges) {
+    if (node.type === 'action' || node.indicator_level == 'strategic') {
+      return true;
+    }
+  
+    for(let edge of edges.filter(edge => edge.from === node.id)) {
+      if (this.isConnectedToOutcome(nodes.find(node => node.id == edge.to), nodes, edges)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   combineData(nodes, edges) {
     // Combine edges data to indicator nodes
+
+    // Prune nodes that do not reach a strategic indicator.
+    // Could be a lot faster, but we're dealing with quite small
+    // graphs here.
+    nodes = nodes.filter(node => this.isConnectedToOutcome(node, nodes, edges));
+    let nodeids = nodes.map(node => node.id);
+    edges = edges.filter(edge => nodeids.includes(edge.to) && nodeids.includes(edge.from));
+
+
     this.indicators = nodes;
     this.indicators.forEach((item, index) => {
       this.indicators[index].from = edges.filter(edge => edge.from === item.id);


### PR DESCRIPTION
Tries to avoid column-crossing links by forcing nodes to be on a leftmost possible column. Also removes nodes that have no path to a strategic level indicator. Fixes within-column links in *the special case* where the within-column links are between column-neighbors, otherwise *produces wrong graphs*.