### PR TITLE
Static pages: clicking a FAQ sets shareable URL

### DIFF
--- a/common/links.js
+++ b/common/links.js
@@ -36,8 +36,11 @@ export function getDashboardLinkProps(query) {
   };
 }
 
-export const replaceHashWithoutScrolling = hash => window
-  .history.replaceState({}, '', `#${hash}`);
+export const replaceHashWithoutScrolling = hash => window.history.replaceState(
+  {}, // state, not used
+  '', // title, not used
+  hash ? `#${hash}` : `${window.location.pathname}${window.location.search}`,
+);
 
 export function IndicatorLink(props) {
   const { id, ...other } = props;

--- a/common/links.js
+++ b/common/links.js
@@ -36,6 +36,9 @@ export function getDashboardLinkProps(query) {
   };
 }
 
+export const replaceHashWithoutScrolling = hash => window
+  .history.replaceState({}, '', `#${hash}`);
+
 export function IndicatorLink(props) {
   const { id, ...other } = props;
 

--- a/components/common/Accordion.js
+++ b/components/common/Accordion.js
@@ -157,7 +157,7 @@ const AccordionBody = ({ children, isOpen, identifier }) => (
 
 AccordionBody.propTypes = {
   isOpen: PropTypes.bool,
-  identifier: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  identifier: PropTypes.number,
 };
 
 Accordion.Item = AccordionItem;

--- a/components/common/Accordion.js
+++ b/components/common/Accordion.js
@@ -50,7 +50,7 @@ export default class Accordion extends React.Component {
     // hash is not available there.
     const getOpenFaqId = () => {
       const hash = window.location.hash;
-      return hash && hash.length > 2 ? hash.substr(2) : undefined;
+      return hash && hash.length > 2 ? parseInt(hash.substr(2)) : undefined;
     };
 
     const open = getOpenFaqId();
@@ -63,7 +63,7 @@ export default class Accordion extends React.Component {
 
   toggleSection = id => () => {
     this.setState(({ open }) => ({
-      open: id == open ? undefined : id,
+      open: id === open ? undefined : id,
     }));
 
     // put opened faq id into URL hash so URL can be shared
@@ -92,7 +92,7 @@ Accordion.defaultProps = {
 };
 
 Accordion.propTypes = {
-  open: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  open: PropTypes.number,
 };
 
 const AccordionItem = ({
@@ -117,7 +117,7 @@ const AccordionItem = ({
 AccordionItem.propTypes = {
   isOpen: PropTypes.bool,
   onClick: PropTypes.func,
-  identifier: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  identifier: PropTypes.number,
 };
 
 const AccordionHeader = ({
@@ -140,7 +140,7 @@ AccordionHeader.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   isOpen: PropTypes.bool,
   onClick: PropTypes.func,
-  identifier: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  identifier: PropTypes.number,
 };
 
 const AccordionBody = ({ children, isOpen, identifier }) => (

--- a/components/common/Accordion.js
+++ b/components/common/Accordion.js
@@ -45,15 +45,15 @@ export default class Accordion extends React.Component {
   };
 
   componentDidMount() {
-    // Read open faq id from location.hash.
+    // Read open question id from location.hash.
     // Unfortunately this can't be done in server side because
     // hash is not available there.
-    const getOpenFaqId = () => {
+    const getOpenQuestionId = () => {
       const hash = window.location.hash;
-      return hash && hash.length > 2 ? parseInt(hash.substr(2)) : undefined;
+      return hash && hash.length > 2 ? hash.substr(2) : undefined;
     };
 
-    const open = getOpenFaqId();
+    const open = getOpenQuestionId();
     if (open) {
       this.setState({
         open,
@@ -62,12 +62,13 @@ export default class Accordion extends React.Component {
   }
 
   toggleSection = id => () => {
+    const prevOpen = this.state.open;
     this.setState(({ open }) => ({
       open: id === open ? undefined : id,
     }));
 
-    // put opened faq id into URL hash so URL can be shared
-    replaceHashWithoutScrolling(`q${id}`);
+    // put opened question id into URL hash so URL can be shared
+    replaceHashWithoutScrolling(id !== prevOpen ? `q${id}` : undefined);
   };
 
   render() {
@@ -75,7 +76,7 @@ export default class Accordion extends React.Component {
       <div className="accordion">
         {React.Children.map(this.props.children, (child, index) => {
           if (child.type !== AccordionItem) return null;
-          const id = child.props.id || index;
+          const id = child.props.id || `${index}`;
           return React.cloneElement(child, {
             isOpen: child.props.open || this.state.open === id,
             onClick: this.toggleSection(id),
@@ -88,11 +89,11 @@ export default class Accordion extends React.Component {
 }
 
 Accordion.defaultProps = {
-  open: 0,
+  open: undefined,
 };
 
 Accordion.propTypes = {
-  open: PropTypes.number,
+  open: PropTypes.string,
 };
 
 const AccordionItem = ({
@@ -117,7 +118,7 @@ const AccordionItem = ({
 AccordionItem.propTypes = {
   isOpen: PropTypes.bool,
   onClick: PropTypes.func,
-  identifier: PropTypes.number,
+  identifier: PropTypes.string,
 };
 
 const AccordionHeader = ({
@@ -140,7 +141,7 @@ AccordionHeader.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   isOpen: PropTypes.bool,
   onClick: PropTypes.func,
-  identifier: PropTypes.number,
+  identifier: PropTypes.string,
 };
 
 const AccordionBody = ({ children, isOpen, identifier }) => (
@@ -157,7 +158,7 @@ const AccordionBody = ({ children, isOpen, identifier }) => (
 
 AccordionBody.propTypes = {
   isOpen: PropTypes.bool,
-  identifier: PropTypes.number,
+  identifier: PropTypes.string,
 };
 
 Accordion.Item = AccordionItem;

--- a/components/common/Accordion.js
+++ b/components/common/Accordion.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Collapse, Button } from 'reactstrap';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { replaceHashWithoutScrolling } from '../../common/links';
 
 const Header = styled.h3`
   display: flex;
@@ -43,10 +44,30 @@ export default class Accordion extends React.Component {
     open: this.props.open
   };
 
-  toggleSection = index => () => {
+  componentDidMount() {
+    // Read open faq id from location.hash.
+    // Unfortunately this can't be done in server side because
+    // hash is not available there.
+    const getOpenFaqId = () => {
+      const hash = window.location.hash;
+      return hash && hash.length > 2 ? hash.substr(2) : undefined;
+    };
+
+    const open = getOpenFaqId();
+    if (open) {
+      this.setState({
+        open,
+      });
+    }
+  }
+
+  toggleSection = id => () => {
     this.setState(({ open }) => ({
-      open: index === open ? undefined : index
+      open: id == open ? undefined : id,
     }));
+
+    // put opened faq id into URL hash so URL can be shared
+    replaceHashWithoutScrolling(`q${id}`);
   };
 
   render() {
@@ -54,10 +75,11 @@ export default class Accordion extends React.Component {
       <div className="accordion">
         {React.Children.map(this.props.children, (child, index) => {
           if (child.type !== AccordionItem) return null;
+          const id = child.props.id || index;
           return React.cloneElement(child, {
-            isOpen: child.props.open || this.state.open === index,
-            onClick: this.toggleSection(index),
-            identifier: index
+            isOpen: child.props.open || this.state.open === id,
+            onClick: this.toggleSection(id),
+            identifier: id,
           });
         })}
       </div>
@@ -70,7 +92,7 @@ Accordion.defaultProps = {
 };
 
 Accordion.propTypes = {
-  open: PropTypes.number,
+  open: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 const AccordionItem = ({
@@ -95,7 +117,7 @@ const AccordionItem = ({
 AccordionItem.propTypes = {
   isOpen: PropTypes.bool,
   onClick: PropTypes.func,
-  identifier: PropTypes.number,
+  identifier: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 const AccordionHeader = ({
@@ -118,7 +140,7 @@ AccordionHeader.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   isOpen: PropTypes.bool,
   onClick: PropTypes.func,
-  identifier: PropTypes.number,
+  identifier: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 const AccordionBody = ({ children, isOpen, identifier }) => (
@@ -135,7 +157,7 @@ const AccordionBody = ({ children, isOpen, identifier }) => (
 
 AccordionBody.propTypes = {
   isOpen: PropTypes.bool,
-  identifier: PropTypes.number,
+  identifier: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 Accordion.Item = AccordionItem;

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -158,7 +158,7 @@ const Content = ({ page }) => {
                   <h2>Usein kysytyt kysymykset</h2>
                   <Accordion>
                     { questions.map(faq => (
-                      <Accordion.Item key={faq.id} id={parseInt(faq.id)}>
+                      <Accordion.Item key={faq.id} id={faq.id}>
                         <Accordion.Header>
                           {faq.title}
                         </Accordion.Header>

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -158,7 +158,7 @@ const Content = ({ page }) => {
                   <h2>Usein kysytyt kysymykset</h2>
                   <Accordion>
                     { questions.map(faq => (
-                      <Accordion.Item key={faq.id} id={faq.id}>
+                      <Accordion.Item key={faq.id} id={parseInt(faq.id)}>
                         <Accordion.Header>
                           {faq.title}
                         </Accordion.Header>

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -70,7 +70,7 @@ query GetStaticPage($plan: ID!, $slug: ID!) {
   }
 }`;
 
-class StaticPage extends React.Component {
+class StaticPage extends React.PureComponent {
   static contextType = PlanContext;
 
   static async getInitialProps({ query }) {
@@ -107,8 +107,7 @@ class StaticPage extends React.Component {
   }
 }
 
-const Content = (props) => {
-  const { page } = props;
+const Content = ({ page }) => {
   const { title, tagline, imageUrl, content, questions } = page;
 
   return (
@@ -159,7 +158,7 @@ const Content = (props) => {
                   <h2>Usein kysytyt kysymykset</h2>
                   <Accordion>
                     { questions.map(faq => (
-                      <Accordion.Item key={faq.id}>
+                      <Accordion.Item key={faq.id} id={faq.id}>
                         <Accordion.Header>
                           {faq.title}
                         </Accordion.Header>
@@ -176,7 +175,7 @@ const Content = (props) => {
           )}
       </div>
     </article>
-  )
+  );
 }
 
 export default StaticPage;


### PR DESCRIPTION
When opening a FAQ in static page, it sets opened FAQ id to URL. When that URL is loaded, the browser opens the linked FAQ and scrolls to it automatically.

**Cons:**
* uses `window.location.hash` for reading because `getInitialProps` does not support hashes, it's run in server-side
* uses `window.history.replaceState` for writing because it does not trigger scrolling like `Router.replace` does